### PR TITLE
 Skip active (still running) time entries in Toggl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+config.ini
+tracking.log*

--- a/processTimeTrackingEntries.py
+++ b/processTimeTrackingEntries.py
@@ -255,6 +255,10 @@ def main():
     for key, grouped_time_entry in grouped_time_entries.items():
         start_time = min(time_entry["start_time"] for time_entry in grouped_time_entry["time_entries"])
 
+        # when Toggl is running (duration is negative), the entry should be skipped.
+        if (time_entry["duration"] < 0):
+            continue
+
         duration = sum(time_entry["duration"] for time_entry in grouped_time_entry["time_entries"])
         duration = str(math.ceil(duration / (float(60) * 15)) * 15) + "m"
 


### PR DESCRIPTION
Hi,

I added a small change that enables you to run the program even while the Toggl timer is running.
I would appreciate if you could pull this change.

Cheers
Kai
