### PR TITLE
Filename bug, toggle running time entry handling and rounding

### DIFF
--- a/processTimeTrackingEntries.py
+++ b/processTimeTrackingEntries.py
@@ -304,7 +304,7 @@ def main():
             start_time = min(time_entry["start_time"] for time_entry in grouped_time_entry["time_entries"])
 
             duration = sum(time_entry["duration"] for time_entry in grouped_time_entry["time_entries"])
-            duration = str(round(duration / (float(60) * 15)) * 15) + "m"
+            duration = str(math.ceil(duration / (float(60) * 15)) * 15) + "m"
 
             if (grouped_time_entry["pid"] is not None) and (all_toggl_projects.get(grouped_time_entry["pid"]) is not None):
                 issue = jira.issue(all_toggl_projects[grouped_time_entry['pid']])

--- a/processTimeTrackingEntries.py
+++ b/processTimeTrackingEntries.py
@@ -205,7 +205,7 @@ def main():
     configuration = read_configuration(config_file)
 
     if (configuration.get('useLogFile') == True):
-        logging.basicConfig(filename=configuration['filename'], level=configuration['logLevel'])
+        logging.basicConfig(filename=configuration['logFile'], level=configuration['logLevel'])
     else:
         logging.basicConfig(level=configuration['logLevel'])
 

--- a/processTimeTrackingEntries.py
+++ b/processTimeTrackingEntries.py
@@ -289,13 +289,15 @@ def main():
                 'created as worklog in JIRA and subsequently tagged in Toggl'.format(
                     str(time_entry['id']), time_entry['description']))
 
+    # when last Toggl time entry is running (duration is negative), all entries should be skipped.
+    if (time_entry["duration"] < 0):
+        _logger.error("Toggl is still running! No time entries will be processed. "
+                        "Stop the current time entry and execute this script again!")
+        return
+
     for key, grouped_time_entry in grouped_time_entries.items():
         if (len(grouped_time_entry["time_entries"]) > 0):
             start_time = min(time_entry["start_time"] for time_entry in grouped_time_entry["time_entries"])
-
-            # when Toggl is running (duration is negative), the entry should be skipped.
-            if (time_entry["duration"] < 0):
-                continue
 
             duration = sum(time_entry["duration"] for time_entry in grouped_time_entry["time_entries"])
             duration = str(round(duration / (float(60) * 15)) * 15) + "m"

--- a/processTimeTrackingEntries.py
+++ b/processTimeTrackingEntries.py
@@ -298,7 +298,7 @@ def main():
                 continue
 
             duration = sum(time_entry["duration"] for time_entry in grouped_time_entry["time_entries"])
-            duration = str(math.ceil(duration / (float(60) * 15)) * 15) + "m"
+            duration = str(round(duration / (float(60) * 15)) * 15) + "m"
 
             if (grouped_time_entry["pid"] is not None) and (all_toggl_projects.get(grouped_time_entry["pid"]) is not None):
                 issue = jira.issue(all_toggl_projects[grouped_time_entry['pid']])

--- a/processTimeTrackingEntries.py
+++ b/processTimeTrackingEntries.py
@@ -293,15 +293,13 @@ def main():
                 'created as worklog in JIRA and subsequently tagged in Toggl'.format(
                     str(time_entry['id']), time_entry['description']))
 
-    # when last Toggl time entry is running (duration is negative), all entries should be skipped.
-    if (time_entry["duration"] < 0):
-        _logger.error("Toggl is still running! No time entries will be processed. "
-                        "Stop the current time entry and execute this script again!")
-        return
-
     for key, grouped_time_entry in grouped_time_entries.items():
         if (len(grouped_time_entry["time_entries"]) > 0):
             start_time = min(time_entry["start_time"] for time_entry in grouped_time_entry["time_entries"])
+
+            # when Toggl is running (duration is negative), the entry should be skipped.
+            if (time_entry["duration"] < 0):
+                continue
 
             duration = sum(time_entry["duration"] for time_entry in grouped_time_entry["time_entries"])
             duration = str(math.ceil(duration / (float(60) * 15)) * 15) + "m"


### PR DESCRIPTION
Hey, 

I found a key error, for the 'filename' field in config.
Furthermore the time_entry[duration] always indicates whether the most recent time entry is still running.
That's the reason I moved it out of the loop. The behavior should not change, but is is clearer and more readable, imo.
One commit addresses a more personal problem I found with rounding up all the time. I think this could be excluded, as it is more personal preference.

Hope you find it helpful,
Jonas
