### PR TITLE
Added optionally having script prompt for password if not set in config.ini

### DIFF
--- a/config_example.ini
+++ b/config_example.ini
@@ -12,6 +12,7 @@ level=DEBUG
 [Jira]
 url=https://jira.mycompany.com
 user=foo
+# delete the 'password' key to have the script prompt for a password
 password=bar
 # remainingEstimatePolicy can be 'auto' or 'leave', the default is auto
 remainingEstimatePolicy=auto

--- a/processTimeTrackingEntries.py
+++ b/processTimeTrackingEntries.py
@@ -27,6 +27,7 @@ import math
 import configparser
 import getopt
 import sys
+from getpass import getpass
 
 from togglwrapper import Toggl
 from jira import Worklog
@@ -68,7 +69,10 @@ def read_configuration(config_file_name):
 
     try:
         configuration['jiraUser'] = config.get("Jira", "user")
-        configuration['jiraPassword'] = config.get("Jira", "password")
+        if (config.has_option('Jira', 'password')):
+            configuration['jiraPassword'] = config.get("Jira", "password")
+        else:
+            configuration['jiraPassword'] = getpass('Please enter Jira password for user "%s": ' % configuration['jiraUser'])
         configuration['jiraUrl'] = config.get("Jira", "url")
         if config.get("Jira", "remainingEstimatePolicy") == 'leave':
             configuration['jiraRePolicy'] = 'leave'


### PR DESCRIPTION
I changed the script so that it will prompt the user to enter a password if it has not been set in the `config.ini` config file. This way, users that do not like saving their password in plain text in a file can choose to enter it on each run of the script, while the script remains backwards compatible with previous versions.