### PR TITLE
Updated toggl API call to new domain

### DIFF
--- a/processTimeTrackingEntries.py
+++ b/processTimeTrackingEntries.py
@@ -219,8 +219,7 @@ def main():
     toggl_end_time = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+00:00")
 
     #toggl = Toggl(configuration['myTogglApiToken'],version='v9')
-    toggl = Toggl(configuration['myTogglApiToken'])
-
+    toggl = Toggl(configuration['myTogglApiToken'], base_url='https://api.track.toggl.com/api')
     if toggl.Workspaces.get_projects(configuration['myWorkspace']) is not None:
         all_toggl_projects = extract_jira_issue_numbers(toggl.Workspaces.get_projects(configuration['myWorkspace']),
                                                         configuration['issue_number_regex_expression'])


### PR DESCRIPTION
Got the following message from Toggl:
```
We noticed activity toward our old API domain (toggl.com) coming from your Toggl Track account. 
If you (or your company) have developed a custom integration, we want to remind you that the usage of the toggl.com domains for the API will be dropped any day now.

Please update your scripts to use the new domain (api.track.toggl.com). For more details, visit the API Docs. 
```
Changed API call accordingly.