### PR TITLE
enable toggl requests with api v9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG IMAGE_TAG=3.12-slim
 FROM ${IMAGE_NAME}:${IMAGE_TAG}
 
 COPY ./processTimeTrackingEntries.py /
-RUN pip install --no-cache-dir python-dateutil togglwrapper jira
+RUN pip install --no-cache-dir python-dateutil jira
+RUN pip install git+https://github.com/Zapgram/togglwrapper
 
 CMD ["python", "/processTimeTrackingEntries.py", "-c", "/config/config.ini"]

--- a/config_example.ini
+++ b/config_example.ini
@@ -21,9 +21,10 @@ remainingEstimatePolicy=auto
 # The Toggl-API-Token can be found in your profile settings at the Toggl website
 apitoken=123abc123abc123abc123abc123abc
 
-# Attention: At this time, only one workspace can be processed. You can get a response containing your workspace ID with the following request:
-# https://www.toggl.com/api/v8/workspaces
+# Attention: At this time, only one workspace in one organization can be processed. You can get a response containing your workspace and organization ID with the following request:
+# https://api.track.toggl.com/api/v9/me/workspaces
 workspace=123456
+organization=1234567
 regex=([A-Z0-9]+-[0-9]+) -.*
 # possible values: day, week
 groupTimeEntriesBy=day


### PR DESCRIPTION
Hi, 

I enabled the processing using toggl v9 api.

It was quite quick and dirty.
There is only a fork of the togglwrapper package you currently use.
Please make sure this does indeed work in your deployment, since we now have a pip dependency directly to github ->   https://github.com/Zapgram/togglwrapper.

I also started working on ditching the dependency on this quite outdated package. Let me know if you are interested in that.
However the error handling code can get out of hand really quick in this situations.